### PR TITLE
Transfer pagination state of MyPlaylists to redux store

### DIFF
--- a/src/components/MyPlaylists/index.js
+++ b/src/components/MyPlaylists/index.js
@@ -45,12 +45,6 @@ class MyPlaylists extends PureComponent {
             myPlaylists: { numberOfTracks, currentOffset, playlistsRemaining }
         } = this.props;
 
-        if (currentOffset + LIMIT >= numberOfTracks) {
-            this.setState({
-                status: STATUS[0]
-            });
-        }
-
         if (currentOffset !== numberOfTracks) {
             fetchMyPlaylists(currentOffset);
             scroll.scrollToBottom();
@@ -78,19 +72,11 @@ class MyPlaylists extends PureComponent {
     }
 
     componentWillReceiveProps(nextProps) {
-        let { status } = this.state;
-        let {
-            myPlaylists: { numberOfTracks, isFetching, currentOffset }
-        } = nextProps;
+        const { myPlaylists: { canLoadMore } } = nextProps;
 
-        if (
-            numberOfTracks > 0 &&
-            numberOfTracks < LIMIT &&
-            !isFetching &&
-            currentOffset === 0
-        ) {
+        if (!canLoadMore) {
             this.setState({
-                status: STATUS[1]
+                status: STATUS[0]
             });
         }
     }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -13,7 +13,8 @@ export function myPlaylists(
         playlists: [],
         numberOfTracks: 0,
         currentOffset: 0,
-        playlistsRemaining: 0
+        playlistsRemaining: 0,
+        canLoadMore: true
     },
     action
 ) {
@@ -24,7 +25,12 @@ export function myPlaylists(
             });
         case RECEIVE_PLAYLISTS:
             const playlists = [...state.playlists, ...action.playlists];
-            let { currentOffset, playlistsRemaining, numberOfTracks } = state;
+            let {
+                currentOffset,
+                playlistsRemaining,
+                numberOfTracks,
+                canLoadMore
+            } = state;
             numberOfTracks = action.numberOfTracks;
 
             if (numberOfTracks < OFFSET_LIMIT) {
@@ -37,9 +43,11 @@ export function myPlaylists(
                 }
             }
 
-            playlistsRemaining = numberOfTracks - currentOffset;
+            if (currentOffset === numberOfTracks) {
+                canLoadMore = false;
+            }
 
-            console.log(numberOfTracks, playlistsRemaining, currentOffset);
+            playlistsRemaining = numberOfTracks - currentOffset;
 
             return Object.assign({}, state, {
                 numberOfTracks: action.numberOfTracks,
@@ -47,6 +55,7 @@ export function myPlaylists(
                 isFetching: false,
                 playlistsRemaining,
                 currentOffset,
+                canLoadMore,
                 playlists
             });
         default:


### PR DESCRIPTION
Transferred the state that is responsible for pagination from MyPlaylists component to the equivalent redux state container. This fixes the bug when the user goes to a different route and when comes back sees the reset data for pagination. 