### PR TITLE
Playlists selection scroll pagination

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -553,3 +553,9 @@ export const setFinalTracksShowStatus = (shouldShowOnlyTracks = false) => ({
     type: SET_FINAL_TRACKS_SHOW_STATUS,
     shouldShowOnlyTracks
 });
+
+export const SET_CURRENT_SELECTION_OFFSET = 'SET_CURRENT_SELECTION_OFFSET';
+export const setCurrentSelectionOffset = (offset = 20) => ({
+    type: SET_CURRENT_SELECTION_OFFSET,
+    offset
+});

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -11,7 +11,7 @@ import {
 } from '../api';
 import { isEmpty, find, propEq } from 'ramda';
 import { formatTracks, getAllPlaylistsTrackIds } from '../utils/helpers';
-import { OFFSET_LIMIT } from '../utils/constants';
+import { OFFSET_LIMIT, PLAYLIST_OFFSET_LIMIT } from '../utils/constants';
 
 export const REQUEST_PLAYLISTS = 'REQUEST_PLAYLISTS';
 const requestPlaylists = () => {
@@ -555,7 +555,7 @@ export const setFinalTracksShowStatus = (shouldShowOnlyTracks = false) => ({
 });
 
 export const SET_CURRENT_SELECTION_OFFSET = 'SET_CURRENT_SELECTION_OFFSET';
-export const setCurrentSelectionOffset = (offset = 20) => ({
+export const setCurrentSelectionOffset = (offset = PLAYLIST_OFFSET_LIMIT) => ({
     type: SET_CURRENT_SELECTION_OFFSET,
     offset
 });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -512,7 +512,7 @@ const receiveMyPlaylistsForSelection = json => {
     return {
         type: RECEIVE_MY_PLAYLISTS_FOR_SELECTION,
         playlists: json.data.body ? json.data.body.items : [],
-        numberOfTracks: json.data.body ? json.data.body.total : 0,
+        totalNumberOfPlaylists: json.data.body ? json.data.body.total : 0,
         receivedAt: Date.now()
     };
 };

--- a/src/components/Dialog/AddExistingForm.js
+++ b/src/components/Dialog/AddExistingForm.js
@@ -145,7 +145,7 @@ class AddExistingForm extends PureComponent {
             </div>
         );
 
-        if (!isFetchingOptions || currentOffset >= 20) {
+        if (!isFetchingOptions || currentOffset >= PLAYLIST_OFFSET_LIMIT) {
             contentComponent = (
                 <FormControl className={classes.formControl} error={error}>
                     <InputLabel htmlFor="playlist-choice">

--- a/src/components/Dialog/AddExistingForm.js
+++ b/src/components/Dialog/AddExistingForm.js
@@ -75,12 +75,6 @@ class AddExistingForm extends PureComponent {
             onFetchPlaylistSelection(currentOffset, PLAYLIST_OFFSET_LIMIT);
             onSetCurrentOffset(currentOffset + PLAYLIST_OFFSET_LIMIT);
         }
-
-        console.log(
-            currentOffset,
-            totalNumberOfPlaylists,
-            ' should start fetching'
-        );
     };
 
     componentDidMount() {
@@ -112,7 +106,8 @@ class AddExistingForm extends PureComponent {
             classes,
             wasAddExistingOpen,
             isFetchingOptions,
-            selectedPlaylist
+            selectedPlaylist,
+            currentOffset
         } = this.props;
         const playlistMenuSelects = playlistOptions.map(
             ({ id, name, images = [] }) => {
@@ -150,7 +145,7 @@ class AddExistingForm extends PureComponent {
             </div>
         );
 
-        if (!isFetchingOptions) {
+        if (!isFetchingOptions || currentOffset >= 20) {
             contentComponent = (
                 <FormControl className={classes.formControl} error={error}>
                     <InputLabel htmlFor="playlist-choice">

--- a/src/components/Dialog/AddExistingForm.js
+++ b/src/components/Dialog/AddExistingForm.js
@@ -45,19 +45,19 @@ const styles = theme => ({
     }
 });
 
-
-
 class AddExistingForm extends PureComponent {
     static propTypes = {
         onSetAddExistingOpenStatus: PropTypes.func.isRequired,
         onFetchPlaylistSelection: PropTypes.func.isRequired,
         selectedPlaylist: PropTypes.string.isRequired,
         wasAddExistingOpen: PropTypes.bool.isRequired,
+        onSetCurrentOffset: PropTypes.func.isRequired,
         isFetchingOptions: PropTypes.bool.isRequired,
         onSelectPlaylist: PropTypes.func.isRequired,
         playlistOptions: PropTypes.array.isRequired,
-        error: PropTypes.bool.isRequired,
+        currentOffset: PropTypes.number.isRequired,
         classes: PropTypes.object.isRequired,
+        error: PropTypes.bool.isRequired,
         wasDialogOpen: PropTypes.bool
     };
 
@@ -65,12 +65,15 @@ class AddExistingForm extends PureComponent {
         const {
             onFetchPlaylistSelection,
             onSetAddExistingOpenStatus,
-            wasAddExistingOpen
+            onSetCurrentOffset,
+            wasAddExistingOpen,
+            currentOffset
         } = this.props;
 
         if (!wasAddExistingOpen) {
             onSetAddExistingOpenStatus(true);
-            onFetchPlaylistSelection(0, PLAYLIST_OFFSET_LIMIT);
+            onFetchPlaylistSelection(currentOffset, PLAYLIST_OFFSET_LIMIT);
+            onSetCurrentOffset(PLAYLIST_OFFSET_LIMIT);
         }
     }
 

--- a/src/components/Dialog/AddExistingForm.js
+++ b/src/components/Dialog/AddExistingForm.js
@@ -12,7 +12,7 @@ import { ListItemIcon, ListItemText } from 'material-ui/List';
 import { MenuItem } from 'material-ui/Menu';
 import { FormControl, FormControlLabel } from 'material-ui/Form';
 import Input, { InputLabel } from 'material-ui/Input';
-import { LIGHT_CYAN_COLOR } from '../../utils/constants';
+import { LIGHT_CYAN_COLOR, PLAYLIST_OFFSET_LIMIT } from '../../utils/constants';
 
 const styles = theme => ({
     formControl: {
@@ -45,7 +45,7 @@ const styles = theme => ({
     }
 });
 
-const MAX_PLAYLISTS_OFFSET_LIMIT = 50;
+
 
 class AddExistingForm extends PureComponent {
     static propTypes = {
@@ -70,7 +70,7 @@ class AddExistingForm extends PureComponent {
 
         if (!wasAddExistingOpen) {
             onSetAddExistingOpenStatus(true);
-            onFetchPlaylistSelection(0, MAX_PLAYLISTS_OFFSET_LIMIT);
+            onFetchPlaylistSelection(0, PLAYLIST_OFFSET_LIMIT);
         }
     }
 

--- a/src/components/Dialog/AddExistingForm.js
+++ b/src/components/Dialog/AddExistingForm.js
@@ -1,11 +1,12 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import Waypoint from 'react-waypoint';
 import { head } from 'ramda';
 import { withStyles } from 'material-ui/styles';
-import Avatar from 'material-ui/Avatar';
-import Select from 'material-ui/Select';
 import { Divider } from 'material-ui';
+import Avatar from 'material-ui/Avatar';
 import TextField from 'material-ui/TextField';
+import Select from 'material-ui/Select';
 import Typography from 'material-ui/Typography';
 import { CircularProgress } from 'material-ui/Progress';
 import { ListItemIcon, ListItemText } from 'material-ui/List';
@@ -49,6 +50,7 @@ class AddExistingForm extends PureComponent {
     static propTypes = {
         onSetAddExistingOpenStatus: PropTypes.func.isRequired,
         onFetchPlaylistSelection: PropTypes.func.isRequired,
+        totalNumberOfPlaylists: PropTypes.number.isRequired,
         selectedPlaylist: PropTypes.string.isRequired,
         wasAddExistingOpen: PropTypes.bool.isRequired,
         onSetCurrentOffset: PropTypes.func.isRequired,
@@ -59,6 +61,26 @@ class AddExistingForm extends PureComponent {
         classes: PropTypes.object.isRequired,
         error: PropTypes.bool.isRequired,
         wasDialogOpen: PropTypes.bool
+    };
+
+    _handleSelectionFetch = () => {
+        const {
+            onSetCurrentOffset,
+            onFetchPlaylistSelection,
+            totalNumberOfPlaylists,
+            currentOffset
+        } = this.props;
+
+        if (currentOffset < totalNumberOfPlaylists) {
+            onFetchPlaylistSelection(currentOffset, PLAYLIST_OFFSET_LIMIT);
+            onSetCurrentOffset(currentOffset + PLAYLIST_OFFSET_LIMIT);
+        }
+
+        console.log(
+            currentOffset,
+            totalNumberOfPlaylists,
+            ' should start fetching'
+        );
     };
 
     componentDidMount() {
@@ -150,6 +172,11 @@ class AddExistingForm extends PureComponent {
                         }}
                     >
                         {playlistMenuSelects}
+                        <Waypoint
+                            onEnter={() => {
+                                this._handleSelectionFetch();
+                            }}
+                        />
                     </Select>
                 </FormControl>
             );

--- a/src/components/Dialog/index.js
+++ b/src/components/Dialog/index.js
@@ -267,6 +267,7 @@ class Dialog extends PureComponent {
                 listOfMyPlaylists,
                 isFetchingOptions,
                 selectedPlaylistId,
+                totalNumberOfPlaylists,
                 currentOffset
             },
             finalPlaylists: {
@@ -312,6 +313,7 @@ class Dialog extends PureComponent {
                     selectedPlaylist={selectedPlaylistId}
                     onSetCurrentOffset={setCurrentSelectionOffset}
                     currentOffset={currentOffset}
+                    totalNumberOfPlaylists={totalNumberOfPlaylists}
                 />
             );
         }

--- a/src/components/Dialog/index.js
+++ b/src/components/Dialog/index.js
@@ -259,13 +259,15 @@ class Dialog extends PureComponent {
         const { error, hasAddExistingError } = this.state;
         const {
             setComponoformAddExistingStatus,
+            setCurrentSelectionOffset,
             setSelectedPlaylist,
             componoform: {
                 finalPlaylistUrl,
                 wasAddExistingOpen,
                 listOfMyPlaylists,
                 isFetchingOptions,
-                selectedPlaylistId
+                selectedPlaylistId,
+                currentOffset
             },
             finalPlaylists: {
                 statusText: loaderText,
@@ -308,6 +310,8 @@ class Dialog extends PureComponent {
                     isFetchingOptions={isFetchingOptions}
                     onSelectPlaylist={this._handlePlaylistSelect}
                     selectedPlaylist={selectedPlaylistId}
+                    onSetCurrentOffset={setCurrentSelectionOffset}
+                    currentOffset={currentOffset}
                 />
             );
         }

--- a/src/connectPage.js
+++ b/src/connectPage.js
@@ -7,9 +7,10 @@ import {
     setOpenStatusPublicPlaylists,
     fetchMyPlaylistsForSelection,
     setOpenStatusFinalPlaylists,
+    setCurrentSelectionOffset,
+    setPublicPlaylistsVisited,
     setOpenStatusMyPlaylists,
     setFinalPlaylistImageURI,
-    setPublicPlaylistsVisited,
     setComponoformOpenStatus,
     setFinalTracksShowStatus,
     addPlaylistTrackToFinal,
@@ -304,6 +305,10 @@ export const mapDispatchToProps = dispatch => ({
 
     setFinalTracksShowStatus(shouldShowOnlyTracks) {
         dispatch(setFinalTracksShowStatus(shouldShowOnlyTracks));
+    },
+
+    setCurrentSelectionOffset(offset) {
+        dispatch(setCurrentSelectionOffset(offset));
     }
 });
 

--- a/src/reducers/componoform.js
+++ b/src/reducers/componoform.js
@@ -5,7 +5,8 @@ import {
     SET_COMPONOFORM_OPEN_STATUS,
     SET_COMPONOFORM_ADD_EXISTING_STATUS,
     SET_SELECTED_PLAYLIST,
-    CLEAR_COMPONOFORM_DATA
+    CLEAR_COMPONOFORM_DATA,
+    SET_CURRENT_SELECTION_OFFSET
 } from '../actions';
 
 const DEFAULT_STATE = {
@@ -14,7 +15,8 @@ const DEFAULT_STATE = {
     wasAddExistingOpen: false,
     listOfMyPlaylists: [],
     finalPlaylistUrl: '',
-    selectedPlaylistId: ''
+    selectedPlaylistId: '',
+    currentOffset: 0
 };
 
 export const componoform = (state = DEFAULT_STATE, action) => {
@@ -49,6 +51,8 @@ export const componoform = (state = DEFAULT_STATE, action) => {
             });
         case CLEAR_COMPONOFORM_DATA:
             return Object.assign({}, state, DEFAULT_STATE);
+        case SET_CURRENT_SELECTION_OFFSET:
+            return Object.assign({}, state, { currentOffset: action.offset });
         default:
             return state;
     }

--- a/src/reducers/componoform.js
+++ b/src/reducers/componoform.js
@@ -16,6 +16,7 @@ const DEFAULT_STATE = {
     listOfMyPlaylists: [],
     finalPlaylistUrl: '',
     selectedPlaylistId: '',
+    totalNumberOfPlaylists: 0,
     currentOffset: 0
 };
 
@@ -37,7 +38,8 @@ export const componoform = (state = DEFAULT_STATE, action) => {
 
             return Object.assign({}, state, {
                 listOfMyPlaylists,
-                isFetchingOptions: false
+                isFetchingOptions: false,
+                totalNumberOfPlaylists: action.totalNumberOfPlaylists
             });
         case SET_COMPONOFORM_OPEN_STATUS:
             return Object.assign({}, state, { wasOpen: action.wasOpen });

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -107,6 +107,7 @@ export const menuButtonStyle = {};
 
 export const SCROLL_DURATION = 500;
 export const OFFSET_LIMIT = 10;
+export const PLAYLIST_OFFSET_LIMIT = 20;
 
 // Max image size is 256KB
 // https://developer.spotify.com/web-api/upload-a-custom-playlist-cover-image/

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -5,7 +5,7 @@ const HOST_URL = window.location.origin;
 const DEV_SERVER_URL = 'http://localhost:3001';
 
 export const replaceTo = path => {
-    window.location.replace(`${HOST_URL}${path}`);
+    window.location.replace(`${DEV_SERVER_URL}${path}`);
 };
 
 export const formatTracks = tracks => {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -5,7 +5,7 @@ const HOST_URL = window.location.origin;
 const DEV_SERVER_URL = 'http://localhost:3001';
 
 export const replaceTo = path => {
-    window.location.replace(`${DEV_SERVER_URL}${path}`);
+    window.location.replace(`${HOST_URL}${path}`);
 };
 
 export const formatTracks = tracks => {


### PR DESCRIPTION
If the user scrolls to the bottom of the selection menu, the action to fetch more playlists is triggered and the next set of (<=20) playlists is fetched unless the offset is bigger than the number of playlists (in which case no need to fetch more anymore).

![componofy_selection_pagination_scroll](https://user-images.githubusercontent.com/9118852/36339240-fc4aa3d4-1375-11e8-9676-951f1ce6447d.gif)
