### PR TITLE
Fetch all tracks (even if > 100) from playlist and search fix

### DIFF
--- a/api/spotify.js
+++ b/api/spotify.js
@@ -127,9 +127,6 @@ export async function getPlaylistTracks(userId, playlistId, options = {}) {
 
         response.body.items = payload;
 
-        console.log('response.body.items:', response.body.items.length);
-        console.log('payload:', payload);
-
         return response;
     } catch (error) {
         return error;

--- a/api/spotify.js
+++ b/api/spotify.js
@@ -115,8 +115,6 @@ export async function getPlaylistTracks(userId, playlistId, options = {}) {
                 options
             );
 
-            console.log('in the loop');
-
             payload = [...payload, ...response.body.items];
             currentOffset = response.body.offset + LIMIT;
             tracksCount = response.body.total;
@@ -129,7 +127,7 @@ export async function getPlaylistTracks(userId, playlistId, options = {}) {
 
         response.body.items = payload;
 
-        console.log('response.body.items:', response.body.items);
+        console.log('response.body.items:', response.body.items.length);
         console.log('payload:', payload);
 
         return response;

--- a/api/spotify.js
+++ b/api/spotify.js
@@ -99,9 +99,40 @@ export async function searchPlaylists(userId, query, options = {}) {
     }
 }
 
-export async function getPlaylistTracks(userID, playlistID, options = {}) {
+export async function getPlaylistTracks(userId, playlistId, options = {}) {
     try {
-        return await spotifyApi.getPlaylistTracks(userID, playlistID, options);
+        const LIMIT = 100;
+        let currentOffset = -1,
+            tracksCount = 0,
+            nextOffset = 0,
+            payload = [],
+            response;
+
+        while (currentOffset < tracksCount) {
+            response = await spotifyApi.getPlaylistTracks(
+                userId,
+                playlistId,
+                options
+            );
+
+            console.log('in the loop');
+
+            payload = [...payload, ...response.body.items];
+            currentOffset = response.body.offset + LIMIT;
+            tracksCount = response.body.total;
+
+            options = {
+                offset: currentOffset,
+                limit: LIMIT
+            };
+        }
+
+        response.body.items = payload;
+
+        console.log('response.body.items:', response.body.items);
+        console.log('payload:', payload);
+
+        return response;
     } catch (error) {
         return error;
     }

--- a/api/spotify.js
+++ b/api/spotify.js
@@ -142,12 +142,13 @@ export async function addTracksToPlaylist(
         const stringToAttach = 'spotify:track:';
         const { accessToken, refreshToken } = userMap[userId];
         let tracks = R.map(R.concat(stringToAttach), trackIDs);
+        let snapshot;
 
         setUpTokens(accessToken, refreshToken);
 
         while (!R.isEmpty(tracks)) {
             const tracksToAdd = tracks.splice(0, 100);
-            const snapshot = await spotifyApi.addTracksToPlaylist(
+            snapshot = await spotifyApi.addTracksToPlaylist(
                 userId,
                 playlistId,
                 tracksToAdd,
@@ -208,12 +209,10 @@ export const uploadPlaylistCoverImage = (userId, playlistId, imageData) => {
             'Content-Type': 'image/jpeg'
         }
     })
-        .then(data => {
-            return {
-                status: data.status,
-                statusText: data.statusText
-            };
-        })
+        .then(data => ({
+            status: data.status,
+            statusText: data.statusText
+        }))
         .catch(error => error);
 };
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -445,7 +445,7 @@ export const cleanPublicSearchResults = () => {
     };
 };
 
-export const searchPublicPlaylists = shouldLoadMore => {
+export const searchPublicPlaylists = (shouldLoadMore = false) => {
     return (dispatch, getState) => {
         const { publicPlaylists: { searchTerm, currentOffset } } = getState();
 
@@ -458,7 +458,8 @@ export const searchPublicPlaylists = shouldLoadMore => {
         }
 
         dispatch(cleanPublicSearchResults());
-        return searchPlaylists(searchTerm, currentOffset).then(json => {
+        // start from 0 offset if the search request is different
+        return searchPlaylists(searchTerm, 0).then(json => {
             dispatch(receivedSearchedPlaylists(json));
             dispatch(setSearchResultsMessage(`Results for "${searchTerm}"`));
         });

--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -140,12 +140,7 @@ class Playlist extends PureComponent {
                     {playlistImage}
                     <ListItemText inset primary={playlist.name} />
                 </ListItem>
-                <Collapse
-                    in={isOpen}
-                    className={classes.collapse}
-                    timeout="auto"
-                    unmountOnExit
-                >
+                <Collapse in={isOpen} timeout="auto" unmountOnExit>
                     <DragDropContext onDragEnd={this._handleDragEnd}>
                         <Droppable droppableId={playlist.id}>
                             {(provided, snapshot) => (

--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -15,6 +15,11 @@ import List from '../List';
 import './Playlist.css';
 
 const styles = theme => ({
+    collapse: {
+        maxHeight: '420px',
+        overflowY: 'auto'
+    },
+
     playlistAvatar: {},
 
     nested: {
@@ -135,7 +140,12 @@ class Playlist extends PureComponent {
                     {playlistImage}
                     <ListItemText inset primary={playlist.name} />
                 </ListItem>
-                <Collapse in={isOpen} timeout="auto" unmountOnExit>
+                <Collapse
+                    in={isOpen}
+                    className={classes.collapse}
+                    timeout="auto"
+                    unmountOnExit
+                >
                     <DragDropContext onDragEnd={this._handleDragEnd}>
                         <Droppable droppableId={playlist.id}>
                             {(provided, snapshot) => (


### PR DESCRIPTION
* Before this patch, the max number of tracks fetched for a playlist was 100. Now it fetches all tracks (>100) from playlist.
* The search offset was not reset to 0 on new search query in `Public` route. Now it resets to 0 on each new search.