### PR TITLE
Set max height for tracklist container if tracks are collapsed

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -185,6 +185,9 @@ export const setOpenStatusMyPlaylists = isOpen => {
     };
 };
 
+// May use this method in the future to
+// make routing share the same open status
+// but not needed for now
 export const setOpenStatusForAllPlaylists = isOpen => (dispatch, getState) => {
     const {
         router: { location: { pathname } },

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -185,6 +185,26 @@ export const setOpenStatusMyPlaylists = isOpen => {
     };
 };
 
+export const setOpenStatusForAllPlaylists = isOpen => (dispatch, getState) => {
+    const {
+        router: { location: { pathname } },
+        navigation: { indexToRouteMap }
+    } = getState();
+
+    switch (pathname) {
+        case indexToRouteMap[0]:
+            dispatch(setOpenStatusMyPlaylists(isOpen));
+            break;
+        case indexToRouteMap[1]:
+            dispatch(setOpenStatusPublicPlaylists(isOpen));
+            break;
+        case indexToRouteMap[2]:
+            dispatch(setOpenStatusFinalPlaylists(isOpen));
+        default:
+            break;
+    }
+};
+
 export const ADD_PLAYLIST_TO_FINAL = 'ADD_PLAYLIST_TO_FINAL';
 export const addPlaylistToFinal = playlist => {
     return {

--- a/src/components/ComponofyPlaylists/index.js
+++ b/src/components/ComponofyPlaylists/index.js
@@ -93,6 +93,7 @@ class ComponofyPlaylists extends PureComponent {
     static propTypes = {
         numberOfTracksInFinalPlaylist: PropTypes.number.isRequired,
         finalPlaylistsHasOpenPlaylist: PropTypes.bool.isRequired,
+        setOpenStatusForAllPlaylists: PropTypes.func.isRequired,
         fetchMyPlaylistsForSelection: PropTypes.func.isRequired,
         setOpenStatusFinalPlaylists: PropTypes.func.isRequired,
         setComponoformOpenStatus: PropTypes.func.isRequired,
@@ -139,12 +140,12 @@ class ComponofyPlaylists extends PureComponent {
 
     _handleClickCollapse = () => {
         const {
-            setOpenStatusFinalPlaylists,
+            setOpenStatusForAllPlaylists,
             finalPlaylistsHasOpenPlaylist
         } = this.props;
 
         this._handleClickOption();
-        setOpenStatusFinalPlaylists(!finalPlaylistsHasOpenPlaylist);
+        setOpenStatusForAllPlaylists(!finalPlaylistsHasOpenPlaylist);
     };
 
     _handleFocusOnSearch = event => {

--- a/src/components/ComponofyPlaylists/index.js
+++ b/src/components/ComponofyPlaylists/index.js
@@ -140,12 +140,12 @@ class ComponofyPlaylists extends PureComponent {
 
     _handleClickCollapse = () => {
         const {
-            setOpenStatusForAllPlaylists,
+            setOpenStatusFinalPlaylists,
             finalPlaylistsHasOpenPlaylist
         } = this.props;
 
         this._handleClickOption();
-        setOpenStatusForAllPlaylists(!finalPlaylistsHasOpenPlaylist);
+        setOpenStatusFinalPlaylists(!finalPlaylistsHasOpenPlaylist);
     };
 
     _handleFocusOnSearch = event => {

--- a/src/components/ComponofyPlaylists/index.js
+++ b/src/components/ComponofyPlaylists/index.js
@@ -267,7 +267,8 @@ class ComponofyPlaylists extends PureComponent {
                 playlists: playlistsFinal,
                 shouldShowOnlyTracks,
                 searchTerm,
-                hasChosenNewCreate
+                hasChosenNewCreate,
+                areAllOpen
             },
             numberOfFinalPlaylists,
             numberOfTracksInFinalPlaylist,
@@ -306,6 +307,7 @@ class ComponofyPlaylists extends PureComponent {
                     items={playlists}
                     showSubItemsOnly={shouldShowOnlyTracks}
                     isPlaylist={true}
+                    collapseHasFixedHeight={!areAllOpen}
                 />
             );
 

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -36,6 +36,7 @@ class List extends PureComponent {
         subheader: PropTypes.string,
         classes: PropTypes.object,
         keyItem: PropTypes.object,
+        collapseHasFixedHeight: PropTypes.bool,
         showSubItemsOnly: PropTypes.bool
     };
 
@@ -50,6 +51,7 @@ class List extends PureComponent {
             onClickMain,
             onClickItem,
             onDragAndDrop,
+            collapseHasFixedHeight,
             ...restProps
         } = this.props;
         let listOfItems, listSub;
@@ -69,6 +71,7 @@ class List extends PureComponent {
                       playlist={playlist}
                       showTracksOnly={showSubItemsOnly}
                       onDragAndDrop={onDragAndDrop}
+                      collapseHasFixedHeight={collapseHasFixedHeight}
                   />
               ))
             : [];

--- a/src/components/MyPlaylists/index.js
+++ b/src/components/MyPlaylists/index.js
@@ -54,6 +54,7 @@ let scroll = Scroll.animateScroll;
 class MyPlaylists extends PureComponent {
     static propTypes = {
         startPlaylistTracksReorderProcess: PropTypes.func.isRequired,
+        setOpenStatusForAllPlaylists: PropTypes.func.isRequired,
         myPlaylistsHasOpenPlaylist: PropTypes.bool.isRequired,
         removePlaylistFromFinal: PropTypes.func.isRequired,
         reorderPlaylistTracks: PropTypes.func.isRequired,
@@ -152,12 +153,12 @@ class MyPlaylists extends PureComponent {
 
     _handleClickCollapse = () => {
         const {
-            setOpenStatusMyPlaylists,
+            setOpenStatusForAllPlaylists,
             myPlaylistsHasOpenPlaylist
         } = this.props;
 
         this._handleClickOption();
-        setOpenStatusMyPlaylists(!myPlaylistsHasOpenPlaylist);
+        setOpenStatusForAllPlaylists(!myPlaylistsHasOpenPlaylist);
     };
 
     _handleInputChange = event => {
@@ -232,6 +233,7 @@ class MyPlaylists extends PureComponent {
             myPlaylists: {
                 playlistsRemaining,
                 canLoadMore,
+                areAllOpen,
                 isFetching,
                 searchTerm,
                 playlists
@@ -311,6 +313,7 @@ class MyPlaylists extends PureComponent {
                         items={playlists}
                         isPlaylist={true}
                         onDragAndDrop={this._handlePlaylistTracksReorder}
+                        collapseHasFixedHeight={areAllOpen}
                     />
                     <Waypoint
                         onEnter={() => {

--- a/src/components/MyPlaylists/index.js
+++ b/src/components/MyPlaylists/index.js
@@ -314,7 +314,7 @@ class MyPlaylists extends PureComponent {
                         items={playlists}
                         isPlaylist={true}
                         onDragAndDrop={this._handlePlaylistTracksReorder}
-                        collapseHasFixedHeight={areAllOpen}
+                        collapseHasFixedHeight={!areAllOpen}
                     />
                     <Waypoint
                         onEnter={() => {

--- a/src/components/MyPlaylists/index.js
+++ b/src/components/MyPlaylists/index.js
@@ -56,6 +56,7 @@ class MyPlaylists extends PureComponent {
         startPlaylistTracksReorderProcess: PropTypes.func.isRequired,
         setOpenStatusForAllPlaylists: PropTypes.func.isRequired,
         myPlaylistsHasOpenPlaylist: PropTypes.bool.isRequired,
+        setOpenStatusMyPlaylists: PropTypes.func.isRequired,
         removePlaylistFromFinal: PropTypes.func.isRequired,
         reorderPlaylistTracks: PropTypes.func.isRequired,
         setPlaylistDragStatus: PropTypes.func.isRequired,
@@ -153,12 +154,12 @@ class MyPlaylists extends PureComponent {
 
     _handleClickCollapse = () => {
         const {
-            setOpenStatusForAllPlaylists,
+            setOpenStatusMyPlaylists,
             myPlaylistsHasOpenPlaylist
         } = this.props;
 
         this._handleClickOption();
-        setOpenStatusForAllPlaylists(!myPlaylistsHasOpenPlaylist);
+        setOpenStatusMyPlaylists(!myPlaylistsHasOpenPlaylist);
     };
 
     _handleInputChange = event => {

--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -42,6 +42,7 @@ class Playlist extends PureComponent {
         playlist: PLAYLIST_PROPTYPE.isRequired,
         onClickIcon: PropTypes.func.isRequired,
         classes: PropTypes.object.isRequired,
+        collapseHasFixedHeight: PropTypes.bool,
         onDragAndDrop: PropTypes.func,
         showPlaylist: PropTypes.bool
     };

--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -95,7 +95,8 @@ class Playlist extends PureComponent {
             playlist,
             containsThisPlaylist,
             classes,
-            showTracksOnly
+            showTracksOnly,
+            collapseHasFixedHeight
         } = this.props;
         const {
             tracks: { list: tracks },
@@ -165,7 +166,14 @@ class Playlist extends PureComponent {
                     {playlistImage}
                     <ListItemText inset primary={playlist.name} />
                 </ListItem>
-                <Collapse in={isOpen} timeout="auto" unmountOnExit>
+                <Collapse
+                    in={isOpen}
+                    className={classNames({
+                        [classes.collapse]: collapseHasFixedHeight
+                    })}
+                    timeout="auto"
+                    unmountOnExit
+                >
                     <DragDropContext onDragEnd={this._handleDragEnd}>
                         <Droppable droppableId={playlist.id}>
                             {(provided, snapshot) => (

--- a/src/components/PublicPlaylists/index.js
+++ b/src/components/PublicPlaylists/index.js
@@ -153,11 +153,11 @@ class PublicPlaylists extends PureComponent {
     _handleClickCollapse = () => {
         const {
             publicPlaylistsHasOpenPlaylist,
-            setOpenStatusForAllPlaylists
+            setOpenStatusPublicPlaylists
         } = this.props;
 
         this._handleClickOption();
-        setOpenStatusForAllPlaylists(!publicPlaylistsHasOpenPlaylist);
+        setOpenStatusPublicPlaylists(!publicPlaylistsHasOpenPlaylist);
     };
 
     _handleFocusOnSearch = event => {

--- a/src/components/PublicPlaylists/index.js
+++ b/src/components/PublicPlaylists/index.js
@@ -48,13 +48,14 @@ class PublicPlaylists extends PureComponent {
     static propTypes = {
         publicPlaylistsHasOpenPlaylist: PropTypes.bool.isRequired,
         setOpenStatusPublicPlaylists: PropTypes.func.isRequired,
+        setOpenStatusForAllPlaylists: PropTypes.func.isRequired,
         setPublicPlaylistsVisited: PropTypes.func.isRequired,
         removePlaylistFromFinal: PropTypes.func.isRequired,
         setSearchResultsMessage: PropTypes.func.isRequired,
-        publicPlaylists: PLAYLISTS_PROPTYPE.isRequired,
         setPublicPlaylistOpen: PropTypes.func.isRequired,
         searchPublicPlaylists: PropTypes.func.isRequired,
         setPublicSearchTerm: PropTypes.func.isRequired,
+        publicPlaylists: PLAYLISTS_PROPTYPE.isRequired,
         addPlaylistToFinal: PropTypes.func.isRequired,
         logOutUser: PropTypes.func.isRequired,
         classes: PropTypes.object.isRequired,
@@ -151,12 +152,12 @@ class PublicPlaylists extends PureComponent {
 
     _handleClickCollapse = () => {
         const {
-            setOpenStatusPublicPlaylists,
-            publicPlaylistsHasOpenPlaylist
+            publicPlaylistsHasOpenPlaylist,
+            setOpenStatusForAllPlaylists
         } = this.props;
 
         this._handleClickOption();
-        setOpenStatusPublicPlaylists(!publicPlaylistsHasOpenPlaylist);
+        setOpenStatusForAllPlaylists(!publicPlaylistsHasOpenPlaylist);
     };
 
     _handleFocusOnSearch = event => {

--- a/src/components/PublicPlaylists/index.js
+++ b/src/components/PublicPlaylists/index.js
@@ -213,7 +213,8 @@ class PublicPlaylists extends PureComponent {
                 searchResultsMessage,
                 canLoadMore,
                 isFetching,
-                playlistsRemaining
+                playlistsRemaining,
+                areAllOpen
             },
             publicPlaylistsHasOpenPlaylist,
             classes
@@ -233,6 +234,7 @@ class PublicPlaylists extends PureComponent {
                     items={playlists}
                     subheader={searchResultsMessage}
                     isPlaylist={true}
+                    collapseHasFixedHeight={!areAllOpen}
                 />
             );
         }

--- a/src/connectPage.js
+++ b/src/connectPage.js
@@ -7,6 +7,7 @@ import {
     removePlaylistTrackFromFinal,
     setOpenStatusPublicPlaylists,
     fetchMyPlaylistsForSelection,
+    setOpenStatusForAllPlaylists,
     setOpenStatusFinalPlaylists,
     setCurrentSelectionOffset,
     setPublicPlaylistsVisited,
@@ -321,6 +322,10 @@ export const mapDispatchToProps = dispatch => ({
 
     setPlaylistDragStatus(playlistId, hasReorderRequest) {
         dispatch(setPlaylistDragStatus(playlistId, hasReorderRequest));
+    },
+
+    setOpenStatusForAllPlaylists(isOpen) {
+        dispatch(setOpenStatusForAllPlaylists(isOpen));
     },
 
     startPlaylistTracksReorderProcess(playlistId, trackId, startPos, endPos) {

--- a/src/reducers/finalPlaylists.js
+++ b/src/reducers/finalPlaylists.js
@@ -28,6 +28,7 @@ const DEFAULT_STATE = {
     searchTerm: '',
     isVisited: false,
     playlistDesc: '',
+    areAllOpen: false,
     imageUri: '',
     hasChosenNewCreate: true,
     isPublic: true
@@ -127,7 +128,10 @@ export const finalPlaylists = (state = DEFAULT_STATE, action) => {
                 playlistMap[playlistId].isOpen = action.isOpen;
             }
 
-            return Object.assign({}, state, { playlists });
+            return Object.assign({}, state, {
+                areAllOpen: action.isOpen,
+                playlists
+            });
         case SET_MERGER_STATUS:
             return Object.assign({}, state, {
                 status: action.status,

--- a/src/reducers/myPlaylists.js
+++ b/src/reducers/myPlaylists.js
@@ -25,6 +25,7 @@ const DEFAULT_STATE = {
     currentOffset: 0,
     playlistsRemaining: 0,
     canLoadMore: true,
+    areAllOpen: false,
     isVisited: false
 };
 
@@ -130,6 +131,7 @@ export const myPlaylists = (state = DEFAULT_STATE, action) => {
             });
 
             return Object.assign({}, state, {
+                areAllOpen: action.isOpen,
                 playlists: myPlaylists
             });
         case SET_MY_SEARCH_TERM:

--- a/src/reducers/publicPlaylists.js
+++ b/src/reducers/publicPlaylists.js
@@ -15,6 +15,7 @@ import { OFFSET_LIMIT } from '../utils/constants';
 
 const DEFAULT_STATE = {
     isFetching: false,
+    areAllOpen: false,
     searchTerm: '',
     searchResultsMessage: '',
     playlists: [],
@@ -115,6 +116,7 @@ export const publicPlaylists = (state = DEFAULT_STATE, action) => {
             });
 
             return Object.assign({}, state, {
+                areAllOpen: action.isOpen,
                 playlists
             });
         case CLEAR_PUBLIC_DATA:

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -69,6 +69,7 @@ export const PLAYLISTS_PROPTYPE = PropTypes.shape({
     numberOfTracks: PropTypes.number.isRequired,
     currentOffset: PropTypes.number.isRequired,
     playlistsRemaining: PropTypes.number.isRequired,
+    areAllOpen: PropTypes.bool.isRequired,
     canLoadMore: PropTypes.bool.isRequired,
     isVisited: PropTypes.bool.isRequired,
     lastUpdated: PropTypes.number

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -5,7 +5,7 @@ const HOST_URL = window.location.origin;
 const DEV_SERVER_URL = 'http://localhost:3001';
 
 export const replaceTo = path => {
-    window.location.replace(`${HOST_URL}${path}`);
+    window.location.replace(`${DEV_SERVER_URL}${path}`);
 };
 
 export const formatTracks = tracks => {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -5,7 +5,7 @@ const HOST_URL = window.location.origin;
 const DEV_SERVER_URL = 'http://localhost:3001';
 
 export const replaceTo = path => {
-    window.location.replace(`${DEV_SERVER_URL}${path}`);
+    window.location.replace(`${HOST_URL}${path}`);
 };
 
 export const formatTracks = tracks => {


### PR DESCRIPTION
The `Collapse` container that contains tracks took all the height space when it was open. Set fixed max height if the currently not all of the playlists are open (un-colapsed).