### PR TITLE
Playlist number of tracks as a badge to the right

### DIFF
--- a/src/components/FooterPanel/index.js
+++ b/src/components/FooterPanel/index.js
@@ -15,7 +15,8 @@ const styles = theme => ({
     root: {
         paddingTop: `${theme.spacing.unit}px`,
         paddingBottom: `${theme.spacing.unit}px`,
-        display: 'flex'
+        display: 'flex',
+        zIndex: theme.zIndex.navDrawer
     },
 
     maintext: {},

--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -3,9 +3,15 @@ import PropTypes from 'prop-types';
 import Collapse from 'material-ui/transitions/Collapse';
 import Typography from 'material-ui/Typography';
 import Avatar from 'material-ui/Avatar';
+import Badge from 'material-ui/Badge';
 import { withStyles } from 'material-ui/styles';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
-import { ListItem, ListItemIcon, ListItemText } from 'material-ui/List';
+import {
+    ListItem,
+    ListItemIcon,
+    ListItemText,
+    ListItemSecondaryAction
+} from 'material-ui/List';
 import {
     PlaylistAdd,
     PlaylistAddCheck,
@@ -28,15 +34,25 @@ const styles = theme => ({
         overflowY: 'auto'
     },
 
+    trackBadge: {
+        color: theme.palette.background.paper,
+        backgroundColor: theme.palette.secondary[500],
+        padding: theme.spacing.unit / 4
+    },
+
+    margin: {
+        margin: theme.spacing.unit * 2
+    },
+
+    nested: {
+        paddingLeft: theme.spacing.unit * 4
+    },
+
     playlistAvatar: {},
 
     progress: {
         margin: `0 ${theme.spacing.unit * 2}px`,
         color: LIGHT_CYAN_COLOR
-    },
-
-    nested: {
-        paddingLeft: theme.spacing.unit * 4
     }
 });
 
@@ -108,6 +124,7 @@ class Playlist extends PureComponent {
             images: playlistImages,
             isOpen: playlistIsOpen
         } = playlist;
+        const nTracks = tracks ? tracks.length : <AccessTime />;
         let playlistClassName = classNames({ 'no-display': showTracksOnly });
         let isOpen = showTracksOnly ? true : playlistIsOpen;
         let playlistIconComponent = containsThisPlaylist ? (
@@ -175,6 +192,16 @@ class Playlist extends PureComponent {
                     </ListItemIcon>
                     {playlistImage}
                     <ListItemText inset primary={playlist.name} />
+                    <Badge
+                        color="default"
+                        badgeContent={nTracks}
+                        className={classes.margin}
+                        classes={{
+                            badge: classes.trackBadge
+                        }}
+                    >
+                        <span />
+                    </Badge>
                 </ListItem>
                 <Collapse
                     in={isOpen}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -5,7 +5,7 @@ const HOST_URL = window.location.origin;
 const DEV_SERVER_URL = 'http://localhost:3001';
 
 export const replaceTo = path => {
-    window.location.replace(`${HOST_URL}${path}`);
+    window.location.replace(`${DEV_SERVER_URL}${path}`);
 };
 
 export const formatTracks = tracks => {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -5,7 +5,7 @@ const HOST_URL = window.location.origin;
 const DEV_SERVER_URL = 'http://localhost:3001';
 
 export const replaceTo = path => {
-    window.location.replace(`${DEV_SERVER_URL}${path}`);
+    window.location.replace(`${HOST_URL}${path}`);
 };
 
 export const formatTracks = tracks => {


### PR DESCRIPTION
* Added the badge with the number of tracks in the playlist. If there is no tracks list given yet, shows the `Alarm` icon as a waiting sign.
* Applied `zIndex` supplied by the Material UI to make the footer panel to have a visibility level priority over nav bar.

![screen shot 2018-02-23 at 12 51 44 am](https://user-images.githubusercontent.com/9118852/36585693-c69ee1ec-1833-11e8-985d-70a1b5553d80.png)
