### PR TITLE
n tracks included from each playlist shown in a green light badge

### DIFF
--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -37,7 +37,8 @@ class List extends PureComponent {
         classes: PropTypes.object,
         keyItem: PropTypes.object,
         collapseHasFixedHeight: PropTypes.bool,
-        showSubItemsOnly: PropTypes.bool
+        showSubItemsOnly: PropTypes.bool,
+        shouldShowTracksIncludedValue: PropTypes.bool
     };
 
     render() {
@@ -52,6 +53,7 @@ class List extends PureComponent {
             onClickItem,
             onDragAndDrop,
             collapseHasFixedHeight,
+            shouldShowTracksIncludedValue,
             ...restProps
         } = this.props;
         let listOfItems, listSub;
@@ -72,6 +74,9 @@ class List extends PureComponent {
                       showTracksOnly={showSubItemsOnly}
                       onDragAndDrop={onDragAndDrop}
                       collapseHasFixedHeight={collapseHasFixedHeight}
+                      shouldShowTracksIncludedValue={
+                          shouldShowTracksIncludedValue
+                      }
                   />
               ))
             : [];

--- a/src/components/MyPlaylists/index.js
+++ b/src/components/MyPlaylists/index.js
@@ -315,6 +315,7 @@ class MyPlaylists extends PureComponent {
                         isPlaylist={true}
                         onDragAndDrop={this._handlePlaylistTracksReorder}
                         collapseHasFixedHeight={!areAllOpen}
+                        shouldShowTracksIncludedValue={true}
                     />
                     <Waypoint
                         onEnter={() => {

--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -77,6 +77,7 @@ class Playlist extends PureComponent {
         onClickIcon: PropTypes.func.isRequired,
         classes: PropTypes.object.isRequired,
         numberOfAddedTracksFromThisPlaylist: PropTypes.number,
+        shouldShowTracksIncludedValue: PropTypes.bool,
         collapseHasFixedHeight: PropTypes.bool,
         onDragAndDrop: PropTypes.func,
         showPlaylist: PropTypes.bool
@@ -132,7 +133,8 @@ class Playlist extends PureComponent {
             classes,
             showTracksOnly,
             collapseHasFixedHeight,
-            numberOfAddedTracksFromThisPlaylist
+            numberOfAddedTracksFromThisPlaylist,
+            shouldShowTracksIncludedValue
         } = this.props;
         const {
             tracks: { list: tracks },
@@ -152,7 +154,10 @@ class Playlist extends PureComponent {
         if (!tracks) {
             playlistIconComponent = <AccessTime />;
         }
-        if (numberOfAddedTracksFromThisPlaylist) {
+        if (
+            numberOfAddedTracksFromThisPlaylist &&
+            shouldShowTracksIncludedValue
+        ) {
             badgeForAddedTracks = (
                 <Badge
                     badgeContent={numberOfAddedTracksFromThisPlaylist}

--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -21,7 +21,11 @@ import {
 import { CircularProgress } from 'material-ui/Progress';
 import classNames from 'classnames';
 import * as R from 'ramda';
-import { PLAYLIST_PROPTYPE, LIGHT_CYAN_COLOR } from '../../utils/constants';
+import {
+    PLAYLIST_PROPTYPE,
+    LIGHT_CYAN_COLOR,
+    SUCCESS_COLOR
+} from '../../utils/constants';
 import TrackList from './TrackList';
 import Loader from '../Loader';
 import List from '../List';
@@ -29,6 +33,8 @@ import List from '../List';
 import './Playlist.css';
 
 const styles = theme => ({
+    badgeSet: {},
+
     collapse: {
         maxHeight: '420px',
         overflowY: 'auto'
@@ -38,6 +44,13 @@ const styles = theme => ({
         color: theme.palette.background.paper,
         backgroundColor: theme.palette.secondary[500],
         padding: theme.spacing.unit / 4
+    },
+
+    includedTracksBadge: {
+        color: SUCCESS_COLOR,
+        backgroundColor: theme.palette.background.paper,
+        padding: theme.spacing.unit / 4,
+        border: `1px solid ${SUCCESS_COLOR}`
     },
 
     margin: {
@@ -63,6 +76,7 @@ class Playlist extends PureComponent {
         playlist: PLAYLIST_PROPTYPE.isRequired,
         onClickIcon: PropTypes.func.isRequired,
         classes: PropTypes.object.isRequired,
+        numberOfAddedTracksFromThisPlaylist: PropTypes.number,
         collapseHasFixedHeight: PropTypes.bool,
         onDragAndDrop: PropTypes.func,
         showPlaylist: PropTypes.bool
@@ -117,7 +131,8 @@ class Playlist extends PureComponent {
             containsThisPlaylist,
             classes,
             showTracksOnly,
-            collapseHasFixedHeight
+            collapseHasFixedHeight,
+            numberOfAddedTracksFromThisPlaylist
         } = this.props;
         const {
             tracks: { list: tracks },
@@ -132,9 +147,23 @@ class Playlist extends PureComponent {
         ) : (
             <PlaylistAdd />
         );
+        let badgeForAddedTracks;
 
         if (!tracks) {
             playlistIconComponent = <AccessTime />;
+        }
+        if (numberOfAddedTracksFromThisPlaylist) {
+            badgeForAddedTracks = (
+                <Badge
+                    badgeContent={numberOfAddedTracksFromThisPlaylist}
+                    className={classes.margin}
+                    classes={{
+                        badge: classes.includedTracksBadge
+                    }}
+                >
+                    <span />
+                </Badge>
+            );
         }
 
         let tracklist = tracks ? (
@@ -192,16 +221,18 @@ class Playlist extends PureComponent {
                     </ListItemIcon>
                     {playlistImage}
                     <ListItemText inset primary={playlist.name} />
-                    <Badge
-                        color="default"
-                        badgeContent={nTracks}
-                        className={classes.margin}
-                        classes={{
-                            badge: classes.trackBadge
-                        }}
-                    >
-                        <span />
-                    </Badge>
+                    <div className={classes.badgeSet}>
+                        {badgeForAddedTracks}
+                        <Badge
+                            badgeContent={nTracks}
+                            className={classes.margin}
+                            classes={{
+                                badge: classes.trackBadge
+                            }}
+                        >
+                            <span />
+                        </Badge>
+                    </div>
                 </ListItem>
                 <Collapse
                     in={isOpen}

--- a/src/components/PublicPlaylists/index.js
+++ b/src/components/PublicPlaylists/index.js
@@ -235,6 +235,7 @@ class PublicPlaylists extends PureComponent {
                     subheader={searchResultsMessage}
                     isPlaylist={true}
                     collapseHasFixedHeight={!areAllOpen}
+                    shouldShowTracksIncludedValue={true}
                 />
             );
         }

--- a/src/connectPage.js
+++ b/src/connectPage.js
@@ -130,6 +130,23 @@ const hasOpenPlaylist = playlistState => {
     );
 };
 
+const getNumberOfAddedTracksFromPlaylist = (finalPlaylists, ownProps) => {
+    if (!ownProps.playlist || R.isEmpty(finalPlaylists)) {
+        return;
+    }
+
+    const { playlist: { id: playlistId } } = ownProps;
+    const { entities: { playlists } = {} } = finalPlaylists;
+    let numberOfAddedTracks = 0;
+
+    if (!R.isEmpty(playlists) && playlists[playlistId]) {
+        let { tracks: { list: tracklist } } = playlists[playlistId];
+        numberOfAddedTracks = tracklist.length;
+    }
+
+    return numberOfAddedTracks;
+};
+
 const mapStateToProps = (state, ownProps) => ({
     finalPlaylists: state.finalPlaylists,
     myPlaylists: state.myPlaylists,
@@ -143,6 +160,10 @@ const mapStateToProps = (state, ownProps) => ({
     ),
     numberOfTracksInFinalPlaylist: getNumberOfTracks(
         getPlaylistsData(state.finalPlaylists.playlists, 'playlists')
+    ),
+    numberOfAddedTracksFromThisPlaylist: getNumberOfAddedTracksFromPlaylist(
+        state.finalPlaylists.playlists,
+        ownProps
     ),
     componoform: state.componoform,
     containsThisPlaylist: playlistIsIn(

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -5,7 +5,7 @@ const HOST_URL = window.location.origin;
 const DEV_SERVER_URL = 'http://localhost:3001';
 
 export const replaceTo = path => {
-    window.location.replace(`${HOST_URL}${path}`);
+    window.location.replace(`${DEV_SERVER_URL}${path}`);
 };
 
 export const formatTracks = tracks => {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -5,7 +5,7 @@ const HOST_URL = window.location.origin;
 const DEV_SERVER_URL = 'http://localhost:3001';
 
 export const replaceTo = path => {
-    window.location.replace(`${DEV_SERVER_URL}${path}`);
+    window.location.replace(`${HOST_URL}${path}`);
 };
 
 export const formatTracks = tracks => {


### PR DESCRIPTION
* The light badge is shown next to the `totalNumberOfPlaylistTracks` badge (pink) to represent the number of tracks included from this playlist in the final set of playlists. 
* It is always only <= total number of playlist tracks and >= 0.
* Represented in a light `SUCCESS` green color
![screen shot 2018-02-23 at 3 23 55 am](https://user-images.githubusercontent.com/9118852/36592135-612377ae-1849-11e8-91f7-732410dcc91c.png)
* only shown in `/app` and `/app/public` routes as it's not needed to show the number from final set in a final set route (`/app/componofy`).
