### PR TITLE
Sticky expand button at the bottom of playlist tracklist collapse

### DIFF
--- a/src/components/Playlist/Expand.js
+++ b/src/components/Playlist/Expand.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button from 'material-ui/Button';
+import { withStyles } from 'material-ui/styles';
+import { ExpandMore, ExpandLess } from 'material-ui-icons';
+import classNames from 'classnames';
+import '../common/common.css';
+
+const styles = theme => ({
+    button: {
+        marginBottom: theme.spacing.unit
+    },
+
+    wrapper: {
+        textAlign: 'center'
+    }
+});
+
+const Expand = props => {
+    return (
+        <footer
+            className={classNames(
+                props.classes.wrapper,
+                { 'sticky-bottom': props.isStickyBottom },
+                { 'sticky-top': props.isStickyTop }
+            )}
+        >
+            <Button
+                fab
+                color="accent"
+                aria-label="expand"
+                onClick={props.onClick}
+                className={props.classes.button}
+            >
+                {props.showUpArrow ? <ExpandLess /> : <ExpandMore />}
+            </Button>
+        </footer>
+    );
+};
+
+Expand.propTypes = {
+    onClick: PropTypes.func.isRequired,
+    classes: PropTypes.object.isRequired,
+    showUpArrow: PropTypes.bool,
+    isStickyBottom: PropTypes.bool,
+    isStickyTop: PropTypes.bool
+};
+
+export default withStyles(styles)(Expand);

--- a/src/components/Playlist/Expand.js
+++ b/src/components/Playlist/Expand.js
@@ -17,22 +17,30 @@ const styles = theme => ({
 });
 
 const Expand = props => {
+    const {
+        onClick,
+        classes,
+        showUpArrow,
+        isStickyBottom,
+        isStickyTop,
+        ...restProps
+    } = props;
+
     return (
         <footer
             className={classNames(
-                props.classes.wrapper,
-                { 'sticky-bottom': props.isStickyBottom },
-                { 'sticky-top': props.isStickyTop }
+                classes.wrapper,
+                { 'sticky-bottom': isStickyBottom },
+                { 'sticky-top': isStickyTop }
             )}
         >
             <Button
-                fab
-                color="accent"
+                onClick={onClick}
+                className={classes.button}
                 aria-label="expand"
-                onClick={props.onClick}
-                className={props.classes.button}
+                {...restProps}
             >
-                {props.showUpArrow ? <ExpandLess /> : <ExpandMore />}
+                {showUpArrow ? <ExpandLess /> : <ExpandMore />}
             </Button>
         </footer>
     );

--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -26,6 +26,7 @@ import {
     LIGHT_CYAN_COLOR,
     SUCCESS_COLOR
 } from '../../utils/constants';
+import Expand from './Expand';
 import TrackList from './TrackList';
 import Loader from '../Loader';
 import List from '../List';
@@ -83,6 +84,10 @@ class Playlist extends PureComponent {
         showPlaylist: PropTypes.bool
     };
 
+    state = {
+        isExpanded: false
+    };
+
     componentDidMount = () => {
         const {
             playlist: { id: playlistID, owner: { id: userId } },
@@ -90,6 +95,14 @@ class Playlist extends PureComponent {
         } = this.props;
 
         fetchPlaylistTracks(userId, playlistID);
+    };
+
+    _handleExpandMore = event => {
+        const { isExpanded } = this.state;
+
+        this.setState({
+            isExpanded: !isExpanded
+        });
     };
 
     _handleClick = event => {
@@ -127,6 +140,7 @@ class Playlist extends PureComponent {
     };
 
     render() {
+        const { isExpanded } = this.state;
         const {
             playlist,
             containsThisPlaylist,
@@ -149,11 +163,22 @@ class Playlist extends PureComponent {
         ) : (
             <PlaylistAdd />
         );
-        let badgeForAddedTracks;
+        let badgeForAddedTracks, expandButton;
 
         if (!tracks) {
             playlistIconComponent = <AccessTime />;
         }
+
+        if (collapseHasFixedHeight && tracks && tracks.length > 4) {
+            expandButton = (
+                <Expand
+                    isStickyBottom={true}
+                    showUpArrow={isExpanded}
+                    onClick={this._handleExpandMore}
+                />
+            );
+        }
+
         if (
             numberOfAddedTracksFromThisPlaylist &&
             shouldShowTracksIncludedValue
@@ -242,7 +267,8 @@ class Playlist extends PureComponent {
                 <Collapse
                     in={isOpen}
                     className={classNames({
-                        [classes.collapse]: collapseHasFixedHeight
+                        [classes.collapse]:
+                            collapseHasFixedHeight && !isExpanded
                     })}
                     timeout="auto"
                     unmountOnExit
@@ -257,6 +283,7 @@ class Playlist extends PureComponent {
                             )}
                         </Droppable>
                     </DragDropContext>
+                    {expandButton}
                 </Collapse>
             </div>
         );

--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -175,6 +175,8 @@ class Playlist extends PureComponent {
                     isStickyBottom={true}
                     showUpArrow={isExpanded}
                     onClick={this._handleExpandMore}
+                    color="accent"
+                    raised
                 />
             );
         }

--- a/src/components/common/common.css
+++ b/src/components/common/common.css
@@ -1,0 +1,9 @@
+.sticky-top {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0; }
+
+.sticky-bottom {
+  position: -webkit-sticky;
+  position: sticky;
+  bottom: 0; }

--- a/src/components/common/common.scss
+++ b/src/components/common/common.scss
@@ -1,1 +1,14 @@
+@mixin sticky {
+    position: -webkit-sticky; // required for Safari
+    position: sticky;
+}
 
+.sticky-top {
+    @include sticky;
+    top: 0;
+}
+
+.sticky-bottom {
+    @include sticky;
+    bottom: 0;
+}


### PR DESCRIPTION
* If user wants to see all tracks of a specific playlist, the user can click on the `Expand` button.
* If the user wants to expand all playlists, the expand button should not be displayed.
![componofy_expand_tracklist](https://user-images.githubusercontent.com/9118852/36654303-7d6f0ef4-1a70-11e8-81a0-55168185742a.gif)

