### PR TITLE
Migrate sticky style to css to make it work with Safari

### DIFF
--- a/src/components/ComponofyPlaylists/index.js
+++ b/src/components/ComponofyPlaylists/index.js
@@ -18,7 +18,6 @@ import {
     SCROLL_DURATION,
     searchKeyMap,
     menuButtonStyle,
-    footerStyle,
     searchStyle
 } from '../../utils/constants';
 import { filterSearchPlaylist, formatPlaylistsData } from '../../utils/helpers';
@@ -419,7 +418,6 @@ class ComponofyPlaylists extends PureComponent {
                         isOpen={settingsIsOpen}
                         menuItems={menuItems}
                         mainText={mainText}
-                        style={footerStyle}
                         mainButtonStyle={mainButtonStyle}
                         buttonMenuStyle={buttonMenuStyle}
                         hasFullWidthButtonMenu={true}

--- a/src/components/ComponofyPlaylists/index.js
+++ b/src/components/ComponofyPlaylists/index.js
@@ -17,8 +17,7 @@ import {
     LIGHT_CYAN_COLOR,
     SCROLL_DURATION,
     searchKeyMap,
-    menuButtonStyle,
-    searchStyle
+    menuButtonStyle
 } from '../../utils/constants';
 import { filterSearchPlaylist, formatPlaylistsData } from '../../utils/helpers';
 import FooterPanel from '../FooterPanel';
@@ -314,7 +313,6 @@ class ComponofyPlaylists extends PureComponent {
                 <Search
                     onChange={this._handleInputChange}
                     inputId="myPlaylistsSearch"
-                    style={searchStyle}
                     value={searchTerm}
                     startAdornment={
                         <SearchIcon

--- a/src/components/FooterPanel/index.js
+++ b/src/components/FooterPanel/index.js
@@ -1,22 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import Button from 'material-ui/Button';
 import Toolbar from 'material-ui/Toolbar';
 import IconButton from 'material-ui/IconButton';
 import { withStyles } from 'material-ui/styles';
 import Typography from 'material-ui/Typography';
-import Settings from '../../containers/Settings';
 import { Settings as SettingsIcon } from 'material-ui-icons';
+import Settings from '../../containers/Settings';
 import CustomMenu from '../CustomMenu';
+import { LIGHT_BLUE_COLOR } from '../../utils/constants';
 
 import './FooterPanel.css';
+import '../common/common.css';
 
 const styles = theme => ({
     root: {
         paddingTop: `${theme.spacing.unit}px`,
         paddingBottom: `${theme.spacing.unit}px`,
         display: 'flex',
-        zIndex: theme.zIndex.navDrawer
+        zIndex: theme.zIndex.navDrawer,
+        background: LIGHT_BLUE_COLOR
     },
 
     maintext: {},
@@ -92,7 +96,12 @@ export const FooterPanel = props => {
     }
 
     return (
-        <Toolbar style={props.style} className={props.classes.root}>
+        <Toolbar
+            style={props.style}
+            classes={{
+                root: classNames(props.classes.root, 'sticky-bottom')
+            }}
+        >
             <section className={props.classes.loaderSection}>
                 {leftSideComponent}
                 {circleTextIcon}

--- a/src/components/MyPlaylists/index.js
+++ b/src/components/MyPlaylists/index.js
@@ -13,7 +13,6 @@ import {
     LIGHT_BLUE_COLOR,
     SCROLL_DURATION,
     searchKeyMap,
-    searchStyle,
     menuButtonStyle,
     OFFSET_LIMIT,
     LOAD_MORE_STATUS
@@ -288,7 +287,6 @@ class MyPlaylists extends PureComponent {
                     <Search
                         onChange={this._handleInputChange}
                         inputId="myPlaylistsSearch"
-                        style={searchStyle}
                         value={searchTerm}
                         startAdornment={
                             <SearchIcon

--- a/src/components/MyPlaylists/index.js
+++ b/src/components/MyPlaylists/index.js
@@ -13,7 +13,6 @@ import {
     LIGHT_BLUE_COLOR,
     SCROLL_DURATION,
     searchKeyMap,
-    footerStyle,
     searchStyle,
     menuButtonStyle,
     OFFSET_LIMIT,
@@ -333,7 +332,6 @@ class MyPlaylists extends PureComponent {
                         mainText={status}
                         anchorEl={anchorEl}
                         menuItems={menuItems}
-                        style={footerStyle}
                         menuButtonStyle={menuButtonStyle}
                     />
                 </div>

--- a/src/components/PublicPlaylists/index.js
+++ b/src/components/PublicPlaylists/index.js
@@ -16,7 +16,6 @@ import {
     OFFSET_LIMIT,
     menuButtonStyle,
     searchKeyMap,
-    footerStyle,
     searchStyle
 } from '../../utils/constants';
 import FooterPanel from '../FooterPanel';
@@ -316,7 +315,6 @@ class PublicPlaylists extends PureComponent {
                             mainText={status}
                             anchorEl={anchorEl}
                             menuItems={menuItems}
-                            style={footerStyle}
                             menuButtonStyle={menuButtonStyle}
                         />
                     </form>

--- a/src/components/PublicPlaylists/index.js
+++ b/src/components/PublicPlaylists/index.js
@@ -15,8 +15,7 @@ import {
     SCROLL_DURATION,
     OFFSET_LIMIT,
     menuButtonStyle,
-    searchKeyMap,
-    searchStyle
+    searchKeyMap
 } from '../../utils/constants';
 import FooterPanel from '../FooterPanel';
 import List from '../List';
@@ -283,7 +282,6 @@ class PublicPlaylists extends PureComponent {
                         <Search
                             onChange={this._handleInputChange}
                             inputId="publicPlaylistsSearch"
-                            style={searchStyle}
                             value={searchTerm}
                             startAdornment={
                                 <SearchIcon

--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -1,15 +1,19 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Input, { InputLabel } from 'material-ui/Input';
+import classNames from 'classnames';
 import { FormControl } from 'material-ui/Form';
 import { withStyles } from 'material-ui/styles';
 import { safeString } from '../../utils/helpers';
 
 import './Search.css';
+import '../common/common.css';
 
 const styles = theme => ({
     formControl: {
-        background: `${theme.palette.common.fullWhite}`
+        background: `${theme.palette.common.fullWhite}`,
+        zIndex: theme.zIndex.navDrawer,
+        display: 'flex'
     },
 
     searchInput: {
@@ -23,7 +27,8 @@ class Search extends PureComponent {
         classes: PropTypes.object.isRequired,
         onChange: PropTypes.func.isRequired,
         inputLabel: PropTypes.string,
-        value: PropTypes.string
+        value: PropTypes.string,
+        style: PropTypes.object
     };
 
     render() {
@@ -44,9 +49,10 @@ class Search extends PureComponent {
 
         return (
             <FormControl
-                style={style}
                 fullWidth
-                className={classes.formControl}
+                classes={{
+                    root: classNames(classes.formControl, 'sticky-top')
+                }}
             >
                 {inputLabelComponent}
                 <Input

--- a/src/components/common/common.css
+++ b/src/components/common/common.css
@@ -1,9 +1,9 @@
 .sticky-top {
-  position: -webkit-sticky;
-  position: sticky;
-  top: 0; }
+  position: -webkit-sticky !important;
+  position: sticky !important;
+  top: 0 !important; }
 
 .sticky-bottom {
-  position: -webkit-sticky;
-  position: sticky;
-  bottom: 0; }
+  position: -webkit-sticky !important;
+  position: sticky !important;
+  bottom: 0 !important; }

--- a/src/components/common/common.scss
+++ b/src/components/common/common.scss
@@ -1,14 +1,14 @@
 @mixin sticky {
-    position: -webkit-sticky; // required for Safari
-    position: sticky;
+    position: -webkit-sticky !important; // required for Safari
+    position: sticky !important;
 }
 
 .sticky-top {
     @include sticky;
-    top: 0;
+    top: 0 !important;
 }
 
 .sticky-bottom {
     @include sticky;
-    bottom: 0;
+    bottom: 0 !important;
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -92,12 +92,6 @@ export const LIGHT_BLUE_COLOR = lightBlue[600];
 export const LIGHT_CYAN_COLOR = cyan[500];
 export const SUCCESS_COLOR = green[600];
 
-export const searchStyle = {
-    position: 'sticky',
-    top: '0',
-    zIndex: '100'
-};
-
 export const menuButtonStyle = {};
 
 export const SCROLL_DURATION = 500;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -92,12 +92,6 @@ export const LIGHT_BLUE_COLOR = lightBlue[600];
 export const LIGHT_CYAN_COLOR = cyan[500];
 export const SUCCESS_COLOR = green[600];
 
-export const footerStyle = {
-    background: LIGHT_BLUE_COLOR,
-    position: 'sticky',
-    bottom: '0'
-};
-
 export const searchStyle = {
     position: 'sticky',
     top: '0',


### PR DESCRIPTION
Search and footer panel did not stick to their respective sides on Safari, so I created a common css rule for `sticky` that is applied across the app to make it compatible with `webkit` browsers as well.
Works for Safari now!