### PR TITLE
Click on unhide scrolls window up to playlist icon

### DIFF
--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -6,7 +6,7 @@ import Avatar from 'material-ui/Avatar';
 import Badge from 'material-ui/Badge';
 import { withStyles } from 'material-ui/styles';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
-import Scroll from 'react-scroll';
+import { Link, Element } from 'react-scroll';
 import {
     ListItem,
     ListItemIcon,
@@ -33,9 +33,6 @@ import Loader from '../Loader';
 import List from '../List';
 
 import './Playlist.css';
-
-const Link = Scroll.Link;
-const Element = Scroll.Element;
 
 const styles = theme => ({
     badgeSet: {},

--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -6,6 +6,7 @@ import Avatar from 'material-ui/Avatar';
 import Badge from 'material-ui/Badge';
 import { withStyles } from 'material-ui/styles';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+import Scroll from 'react-scroll';
 import {
     ListItem,
     ListItemIcon,
@@ -32,6 +33,9 @@ import Loader from '../Loader';
 import List from '../List';
 
 import './Playlist.css';
+
+const Link = Scroll.Link;
+const Element = Scroll.Element;
 
 const styles = theme => ({
     badgeSet: {},
@@ -179,6 +183,14 @@ class Playlist extends PureComponent {
                     raised
                 />
             );
+
+            if (isExpanded) {
+                expandButton = (
+                    <Link to={isExpanded ? playlist.id : null} spy={true}>
+                        {expandButton}
+                    </Link>
+                );
+            }
         }
 
         if (
@@ -249,7 +261,12 @@ class Playlist extends PureComponent {
                         className="playlist-icon"
                         onClick={this._handleIconClick}
                     >
-                        {playlistIconComponent}
+                        <Element
+                            id={`element-playlist-${playlist.id}`}
+                            name={playlist.id}
+                        >
+                            {playlistIconComponent}
+                        </Element>
                     </ListItemIcon>
                     {playlistImage}
                     <ListItemText inset primary={playlist.name} />


### PR DESCRIPTION
For better user experience, if user clicks on "unexpand" the playlist tracklist the window will be scrolled up the the playlist icon. This creates a better user experience since the user doesn't have to scroll to the top to see the playlist that was expanded.

![componofy_expand_tracklist_scroll_back](https://user-images.githubusercontent.com/9118852/36660184-13651f0a-1a8c-11e8-9789-8180cbe898ca.gif)
